### PR TITLE
Standardized anglicized headword

### DIFF
--- a/data/persons/tei/saints/tei/1530.xml
+++ b/data/persons/tei/saints/tei/1530.xml
@@ -17,6 +17,7 @@
                 <editor role="general" ref="http://syriaca.org/documentation/editors.xml#dmichelson">David A. Michelson</editor>
                 <editor role="creator" ref="http://syriaca.org/documentation/editors.xml#jnmsaintlaurent">Jeanne-Nicole Mellon Saint-Laurent</editor>
                 <editor role="creator" ref="http://syriaca.org/documentation/editors.xml#dmichelson">David A. Michelson</editor>
+                <editor role="creator" ref="http://syriaca.org/documentation/editors.xml#jwalters">James E. Walters</editor>
                 <respStmt>
                     <resp>Editing, proofreading, data entry and revision by</resp>
                     <name type="person" ref="http://syriaca.org/documentation/editors.xml#jnmsaintlaurent">Jeanne-Nicole Mellon Saint-Laurent</name>
@@ -32,6 +33,10 @@
                 <respStmt>
                     <resp>Editing and Syriac data proofreading by</resp>
                     <name ref="http://syriaca.org/documentation/editors.xml#abarschabo">Aram Bar Schabo</name>
+                </respStmt>
+                <respStmt>
+                    <resp>Editing by</resp>
+                    <name ref="http://syriaca.org/documentation/editors.xml#jwalters">James E. Walters</name>
                 </respStmt>
                 <respStmt>
                     <resp>Entries adapted from the work of</resp>
@@ -151,6 +156,7 @@
             </langUsage>
         </profileDesc>
         <revisionDesc status="draft">
+            <change who="http://syriaca.org/documentation/editors.xml#jwalters" when="2016-05-24-04:00">Standardized anglicized name in headword</change>
             <change who="http://syriaca.org/documentation/editors.xml#wsalesky" when="2015-10-29-04:00">Added abstract generated from current attestations</change>
             <change who="http://syriaca.org/documentation/editors.xml#wsalesky" when="2015-10-20-04:00">Added attestation for with related works</change>
             <change who="http://syriaca.org/documentation/editors.xml#dmichelson" n="1.0" when="2015-10-19-04:00">CREATED: person</change>
@@ -161,7 +167,8 @@
             <listPerson>
                 <person xml:id="saint-1530" ana="#syriaca-saint">
                     <persName xml:id="name1530-1" xml:lang="syr" syriaca-tags="#syriaca-headword" source="#bib1530-1">ܥܒܕܐܠܥܠܩ</persName>
-                    <persName xml:id="name1530-2" xml:lang="en-x-gedsh" syriaca-tags="#syriaca-headword">Abdālʿaleq</persName>
+                    <persName xml:id="name1530-2" xml:lang="en-x-gedsh">Abdālʿaleq</persName>
+                    <persName xml:id="name1530-5" xml:lang="en" syriaca-tags="#syriaca-headword">ʿAbdalʿaleq</persName>
                     <persName xml:id="name1530-3" xml:lang="fr-x-zanetti" source="#bib1530-1">ʾAḇdālʾaleq</persName>
                     <persName xml:id="name1530-4" xml:lang="fr" source="#bib1530-1">‘Abd al-‘Aleq</persName>
                     <idno type="URI">http://syriaca.org/person/1530</idno>


### PR DESCRIPTION
Added ʿ for ayin at the beginning and removed diacritic mark over a